### PR TITLE
dynamic schema selection based on dict keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,72 @@ where it does implement a feature it doesn't always implement it in the exact
 same way.
 
 The main reason it exists is to support some of the things that Cerberus doesn't
-do
+do.
+
+## Schema selection based on dict keys
+
+Often types when `anyof` (or similar rules) are used, what we really want to do
+is *select* a schema based on dict keys.
+
+There are two options for this:
+
+### when_key_is
+
+Use this when you have dictionaries that have a fixed key, such as `"type"`,
+which specifies some specific format to use. For example, if you have data that
+can look like this:
+
+```json
+{"type": "elephant", "trunk_length": 60}
+{"type": "eagle", "wingspan": 50}
+```
+
+Then you would use `when_key_is`, like this:
+
+```json
+{
+    "type": "dict",
+    "when_key_is": {
+        "key": "type",
+        "choices": {
+            "elephant": {
+                "schema": {"trunk_length": {"type": "integer"}}
+            },
+            "eagle": {
+                "schema": {"wingspan": {"type": "integer"}}
+            },
+        }
+    }
+}
+```
+
+### when_key_exists
+
+Use this when you have dictionaries where you must choose the schema based on
+keys that exist in the data exclusively for their type of data. For example, if
+you have data that can look like this:
+
+```json
+{"image_url": "foo.jpg", "width": 30}
+{"color": "red"}
+```
+
+Then you would use `when_key_exists`, like this:
+
+```json
+{
+    "type": "dict",
+    "when_key_exists": {
+        "image_url": {
+            "schema": {"image_url": {"type": "string"}, "width": {"type": "integer"}}
+        },
+        "color": {
+            "schema": {"color": {"type": "string"}}
+        },
+    }
+}
+```
+
 
 ## normalization inside of *of-rules
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ do.
 
 ## Schema selection based on dict keys
 
-Often types when `anyof` (or similar rules) are used, what we really want to do
-is *select* a schema based on dict keys.
+Often times when `anyof` or `oneof` are used, what we really want to do is
+*select* a schema based on dict keys.
 
 There are two options for this:
 

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -29,6 +29,13 @@ class DictFieldNotFound(SureError):
     stack = attr.ib()
 
 @attr.s
+class ExpectedOneField(SureError):
+    fmt = 'One of the following fields must be defined: {expected} in {value!r}'
+    expected = attr.ib()
+    value = attr.ib()
+    stack = attr.ib()
+
+@attr.s
 class BadType(SureError):
     fmt = '{value!r} must be of {type_} type'
     value = attr.ib()

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -16,8 +16,11 @@ def Dict(required=True, anyof=None, schema={}, **kwargs):
         kwargs['anyof'] = anyof
     return mk(None, kwargs, type='dict', schema=schema, required=required)
 
-def DictChoice(choices, key=None):
-    return {'type': 'dict', 'schema_choice': {'key': key, 'choices': choices}}
+def DictWhenKeyIs(key, choices):
+    return {'type': 'dict', 'when_key_is': {'key': key, 'choices': choices}}
+
+def DictWhenKeyExists(choices):
+    return {'type': 'dict', 'when_key_exists': choices}
 
 def SubSchema(_d=None, **kwargs):
     return {'schema': mk(_d, kwargs)}

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -11,16 +11,18 @@ def mk(d, kw, **morekw):
     schema.update(morekw)
     return schema
 
-def Dict(required=True, anyof=None, schema={}, **kwargs):
+def Dict(required=True, anyof=None, schema=None, **kwargs):
+    if schema is None:
+        schema = {}
     if anyof is not None:
         kwargs['anyof'] = anyof
     return mk(None, kwargs, type='dict', schema=schema, required=required)
 
-def DictWhenKeyIs(key, choices):
-    return {'type': 'dict', 'when_key_is': {'key': key, 'choices': choices}}
+def DictWhenKeyIs(key, choices, **kwargs):
+    return Dict(when_key_is={'key': key, 'choices': choices}, **kwargs)
 
 def DictWhenKeyExists(choices):
-    return {'type': 'dict', 'when_key_exists': choices}
+    return Dict(when_key_exists=choices)
 
 def SubSchema(_d=None, **kwargs):
     return {'schema': mk(_d, kwargs)}

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -16,6 +16,9 @@ def Dict(required=True, anyof=None, schema={}, **kwargs):
         kwargs['anyof'] = anyof
     return mk(None, kwargs, type='dict', schema=schema, required=required)
 
+def DictChoice(choices, key=None):
+    return {'type': 'dict', 'schema_choice': {'key': key, 'choices': choices}}
+
 def SubSchema(_d=None, **kwargs):
     return {'schema': mk(_d, kwargs)}
 

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -21,8 +21,8 @@ def Dict(required=True, anyof=None, schema=None, **kwargs):
 def DictWhenKeyIs(key, choices, **kwargs):
     return Dict(when_key_is={'key': key, 'choices': choices}, **kwargs)
 
-def DictWhenKeyExists(choices):
-    return Dict(when_key_exists=choices)
+def DictWhenKeyExists(choices, **kwargs):
+    return Dict(when_key_exists=choices, **kwargs)
 
 def SubSchema(_d=None, **kwargs):
     return {'schema': mk(_d, kwargs)}

--- a/test_sure.py
+++ b/test_sure.py
@@ -398,29 +398,14 @@ def test_coerce_raises():
     assert ei.value.value == 'hello'
     assert type(ei.value.exception) == ZeroDivisionError
 
-choice_schema = {
-    'type': 'dict',
-    'when_key_is': {
-        'key': 'type',
-        'choices': {
-            'foo': {
-                'schema': {'foo_sibling': S.String()},
-            },
-            'bar': {
-                'schema': {'bar_sibling': S.Integer()},
-            }
-        }
+choice_schema = S.DictWhenKeyIs(
+    'type',
+    {
+        'foo': {'schema': {'foo_sibling': S.String()}},
+        'bar': {'schema': {'bar_sibling': S.Integer()}},
     }
-}
+)
 
-def test_nicer_syntax_for_when_key_is():
-    assert choice_schema == S.DictWhenKeyIs(
-        key='type',
-        choices={
-            'foo': {'schema': {'foo_sibling': S.String()}},
-            'bar': {'schema': {'bar_sibling': S.Integer()}},
-        }
-    )
 
 def test_when_key_is():
     v = {'type': 'foo', 'foo_sibling': 'bar'}
@@ -468,19 +453,10 @@ def test_when_key_is_common_schema():
     v = {'type': 'bar', 'bar_sibling': 3, 'common!': 'yup'}
     assert normalize_schema(schema, v) == v
 
-choice_existence_schema = {
-    'type': 'dict',
-    'when_key_exists': {
-        'image': {'schema': {'image': S.String(), 'width': S.Integer()}},
-        'pattern': {'schema': {'pattern': S.Dict(), 'color': S.String()}},
-    }
-}
-
-def test_nicer_syntax_for_when_key_exists():
-    assert choice_existence_schema == S.DictWhenKeyExists({
-        'image': {'schema': {'image': S.String(), 'width': S.Integer()}},
-        'pattern': {'schema': {'pattern': S.Dict(), 'color': S.String()}},
-    })
+choice_existence_schema = S.DictWhenKeyExists({
+    'image': {'schema': {'image': S.String(), 'width': S.Integer()}},
+    'pattern': {'schema': {'pattern': S.Dict(), 'color': S.String()}},
+})
 
 def test_when_key_exists():
     v = {'image': 'foo', 'width': 3}


### PR DESCRIPTION
Often times when `anyof` (or similar rules) are used, what we really want to do is *select* a schema based on dict keys.

This PR introduces two different options for this.

### when_key_is

Use this when you have dictionaries that have a fixed key, such as `"type"`, which specifies some specific format to use. For example, if you have data that can look like this:

```json
{"type": "elephant", "trunk_length": 60}
{"type": "eagle", "wingspan": 50}
```

Then you would use `when_key_is`, like this:

```json
{
    "type": "dict",
    "when_key_is": {
        "key": "type",
        "choices": {
            "elephant": {
                "schema": {"trunk_length": {"type": "integer"}}
            },
            "eagle": {
                "schema": {"wingspan": {"type": "integer"}}
            },
        }
    }
}
```

### when_key_exists

Use this when you have dictionaries where you must choose the schema based on keys that exist in the data exclusively for their type of data. For example, if you have data that can look like this:

```json
{"image_url": "foo.jpg", "width": 30}
{"color": "red"}
```

Then you would use `when_key_exists`, like this:

```json
{
    "type": "dict",
    "when_key_exists": {
        "image_url": {
            "schema": {"image_url": {"type": "string"}, "width": {"type": "integer"}}
        },
        "color": {
            "schema": {"color": {"type": "string"}}
        },
    }
}
```

## Questions

- Does anyone have suggestions for better names than `when_key_is` and `when_key_exists`?
- Or better names for `DictWhenKeyIs` and `DictWhenKeyExists`?