### PR TITLE
Add support for defining registered subschemas in-line

### DIFF
--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -27,18 +27,14 @@ class Context(object):
 
     def set_allow_unknown(self, x):
         return Context(
-            stack=self.stack,
-            allow_unknown=x,
-            schema_registry=self.schema_registry,
-            )
+            stack=self.stack, allow_unknown=x, schema_registry=self.schema_registry
+        )
 
     def register_schemas(self, registry):
         reg = self.schema_registry.copy()
         reg.update(registry)
         return Context(
-            stack=self.stack,
-            allow_unknown=self.allow_unknown,
-            schema_registry=reg,
+            stack=self.stack, allow_unknown=self.allow_unknown, schema_registry=reg
         )
 
     def find_schema(self, name):
@@ -157,7 +153,7 @@ class Normalizer(object):
         schema = self.schema.copy()
         new_schema = ctx.find_schema(directive_value)
         schema.update(new_schema)
-        del schema['schema_ref']
+        del schema["schema_ref"]
         return _ShortCircuit(_normalize_schema(schema, value, ctx))
 
     @directive("allow_unknown")

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -12,30 +12,22 @@ from . import errors as E
 __all__ = ["normalize_dict", "normalize_schema"]
 
 
-@attr.s
+@attr.s(frozen=True)
 class Context(object):
     allow_unknown = attr.ib()
     stack = attr.ib(factory=tuple)
     schema_registry = attr.ib(factory=dict)
 
     def push_stack(self, x):
-        return Context(
-            stack=self.stack + (x,),
-            allow_unknown=self.allow_unknown,
-            schema_registry=self.schema_registry,
-        )
+        return attr.evolve(self, stack=self.stack + (x,))
 
     def set_allow_unknown(self, x):
-        return Context(
-            stack=self.stack, allow_unknown=x, schema_registry=self.schema_registry
-        )
+        return attr.evolve(self, allow_unknown=x)
 
     def register_schemas(self, registry):
         reg = self.schema_registry.copy()
         reg.update(registry)
-        return Context(
-            stack=self.stack, allow_unknown=self.allow_unknown, schema_registry=reg
-        )
+        return attr.evolve(self, schema_registry=reg)
 
     def find_schema(self, name):
         return self.schema_registry[name]


### PR DESCRIPTION
This allows a nice declarative way to implement recursive schemas, instead of requiring Python code to set up the registry. See README.md changes for documentation.