### PR TITLE
add support for keyschema and valueschema

### DIFF
--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -272,6 +272,19 @@ class Normalizer(object):
                 raise E.RegexMismatch(value, directive_value, ctx.stack)
         return (value, ctx)
 
+    @directive("keyschema")
+    def handle_keyschema(self, value, directive_value, ctx):
+        for k in list(value.keys()):
+            new_key = _normalize_schema(directive_value, k, ctx)
+            value[new_key] = value.pop(k)
+        return (value, ctx)
+
+    @directive("valueschema")
+    def handle_valueschema(self, value, directive_value, ctx):
+        for k, v in value.items():
+            value[k] = _normalize_schema(directive_value, v, ctx)
+        return (value, ctx)
+
     @directive("schema")
     def handle_schema(self, value, directive_value, ctx):
         # The meaning of a `schema` key inside a schema changes based on the

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -13,11 +13,11 @@ def mk(d, kw, **morekw):
 
 
 def Dict(required=True, anyof=None, schema=None, **kwargs):
-    if schema is None:
-        schema = {}
+    if schema is not None:
+        kwargs['schema'] = schema
     if anyof is not None:
         kwargs["anyof"] = anyof
-    return mk(None, kwargs, type="dict", schema=schema, required=required)
+    return mk(None, kwargs, type="dict", required=required)
 
 
 def DictWhenKeyIs(key, choices, **kwargs):

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -14,7 +14,7 @@ def mk(d, kw, **morekw):
 
 def Dict(required=True, anyof=None, schema=None, **kwargs):
     if schema is not None:
-        kwargs['schema'] = schema
+        kwargs["schema"] = schema
     if anyof is not None:
         kwargs["anyof"] = anyof
     return mk(None, kwargs, type="dict", required=required)

--- a/test_sure.py
+++ b/test_sure.py
@@ -24,7 +24,8 @@ def test_valueschema():
 
 def test_valueschema_normalizes_values():
     schema = S.Dict(allow_unknown=True, valueschema=S.Integer(coerce=int))
-    assert normalize_schema(schema, {"foo": 3, 52: '52'}) == {"foo": 3, 52: 52}
+    assert normalize_schema(schema, {"foo": 3, 52: "52"}) == {"foo": 3, 52: 52}
+
 
 def test_keyschema():
     schema = S.Dict(allow_unknown=True, keyschema=S.String())

--- a/test_sure.py
+++ b/test_sure.py
@@ -15,6 +15,29 @@ def test_dict_of_int():
     assert normalize_dict(id_int, sample) == sample
 
 
+def test_valueschema():
+    schema = S.Dict(allow_unknown=True, valueschema=S.Integer())
+    assert normalize_schema(schema, {"foo": 3, 52: 52}) == {"foo": 3, 52: 52}
+    with pytest.raises(E.BadType):
+        normalize_schema(schema, {"foo": "3"})
+
+
+def test_valueschema_normalizes_values():
+    schema = S.Dict(allow_unknown=True, valueschema=S.Integer(coerce=int))
+    assert normalize_schema(schema, {"foo": 3, 52: '52'}) == {"foo": 3, 52: 52}
+
+def test_keyschema():
+    schema = S.Dict(allow_unknown=True, keyschema=S.String())
+    assert normalize_schema(schema, {"foo": 3, "bar": None}) == {"foo": 3, "bar": None}
+    with pytest.raises(E.BadType):
+        normalize_schema(schema, {"foo": 3, 52: "bar"})
+
+
+def test_keyschema_normalizes_keys():
+    schema = S.Dict(allow_unknown=True, keyschema=S.String(coerce=str))
+    assert normalize_schema(schema, {31: 4, 52: 6}) == {"31": 4, "52": 6}
+
+
 def test_bad_type():
     sample = {"id": "3"}
     with pytest.raises(E.BadType) as ei:


### PR DESCRIPTION
Adds support for `keyschema` and `valueschema`.

Since sureberus both normalizes and validates at the same time, the behavior of a schema using keyschema and valueschema can be a bit different from Cerberus.

Sureberus validates `keyschema` and `valueschema` *before* processing the regular `schema` directive. So, given a schema like this:

```python
schema = {
    'type': 'dict',
    'valueschema': {'type': 'string', 'coerce': str},
    'schema': {
        'foo': {'type': 'string'},
    }
}
```

This would work fine in sureberus, given a value like `{'foo': 3}`. However, if you moved the `'coerce'` out of the `'valueschema'` and into the schema for `foo`, it will fail with a BadType error since the valueschema will not like that the `3` is not a string, since it processes the `valueschema` first.

There may be ways to solve this problem, but I'm just going to leave it as-is for now, since I don't need anything fancier yet.