### PR TITLE
Allow specifying a default choice for "when_key_is"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ same way.
 The main reason it exists is to support some of the things that Cerberus doesn't
 do.
 
+## normalization inside of *of-rules
+
+The primary important difference is that you can use sureberus if you want to
+use transforming directives, such as `default` or `coerce`, while also
+validating the document. Cerberus only allows you to do one or the other. Most
+often, this limitation becomes a problem when you want to use an
+[*of-rule](http://docs.python-cerberus.org/en/stable/validation-rules.html#of-rules).
+
 ## Schema selection based on dict keys
 
 Often times when `anyof` or `oneof` are used, what we really want to do is
@@ -46,6 +54,10 @@ Then you would use `when_key_is`, like this:
 }
 ```
 
+You can also specify a `default_choice` inside of the `when_key_is` directive,
+to specify which choice to use if the (e.g.) `type` key is elided from the
+value being validated.
+
 ### when_key_exists
 
 Use this when you have dictionaries where you must choose the schema based on
@@ -72,13 +84,6 @@ Then you would use `when_key_exists`, like this:
     }
 }
 ```
-
-
-## normalization inside of *of-rules
-
-The primary important difference is that you can use sureberus if you want to
-use `default` or `coerce` inside of a
-[*of-rule](http://docs.python-cerberus.org/en/stable/validation-rules.html#of-rules).
 
 
 ## In-line schema registries

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -181,8 +181,8 @@ class Normalizer(object):
         if choice_key not in new_schema.setdefault("schema", {}):
             new_schema["schema"][choice_key] = {"allowed": allowed_choices}
         if choice_key not in value:
-            if 'default_choice' in directive_value:
-                chosen_type = directive_value['default_choice']
+            if "default_choice" in directive_value:
+                chosen_type = directive_value["default_choice"]
             else:
                 raise E.DictFieldNotFound(choice_key, value, ctx.stack)
         else:

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -181,8 +181,12 @@ class Normalizer(object):
         if choice_key not in new_schema.setdefault("schema", {}):
             new_schema["schema"][choice_key] = {"allowed": allowed_choices}
         if choice_key not in value:
-            raise E.DictFieldNotFound(choice_key, value, ctx.stack)
-        chosen_type = value[choice_key]
+            if 'default_choice' in directive_value:
+                chosen_type = directive_value['default_choice']
+            else:
+                raise E.DictFieldNotFound(choice_key, value, ctx.stack)
+        else:
+            chosen_type = value[choice_key]
         if chosen_type not in directive_value["choices"]:
             raise E.DisallowedValue(
                 chosen_type, allowed_choices, ctx.push_stack(choice_key).stack

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -20,8 +20,15 @@ def Dict(required=True, anyof=None, schema=None, **kwargs):
     return mk(None, kwargs, type="dict", required=required)
 
 
-def DictWhenKeyIs(key, choices, **kwargs):
-    return Dict(when_key_is={"key": key, "choices": choices}, **kwargs)
+class _MISSING(object):
+    pass
+
+
+def DictWhenKeyIs(key, choices, default_choice=_MISSING, **kwargs):
+    when_key_is = {"key": key, "choices": choices}
+    if default_choice is not _MISSING:
+        when_key_is['default_choice'] = default_choice
+    return Dict(when_key_is=when_key_is, **kwargs)
 
 
 def DictWhenKeyExists(choices, **kwargs):

--- a/test_sure.py
+++ b/test_sure.py
@@ -588,6 +588,14 @@ def test_when_key_is_not_found():
     assert ei.value.key == "type"
 
 
+def test_when_key_is_default():
+    schema = deepcopy(choice_schema)
+    schema["when_key_is"]["default_choice"] = "foo"
+    assert normalize_schema(schema, {"foo_sibling": "hello"}) == {
+        "foo_sibling": "hello",
+    }
+
+
 choice_existence_schema = S.DictWhenKeyExists(
     {
         "image": {"schema": {"image": S.String(), "width": S.Integer()}},

--- a/test_sure.py
+++ b/test_sure.py
@@ -20,7 +20,7 @@ def test_valueschema():
     assert normalize_schema(schema, {"foo": 3, 52: 52}) == {"foo": 3, 52: 52}
     with pytest.raises(E.BadType) as ei:
         normalize_schema(schema, {"foo": "3"})
-    assert ei.value.stack == ('foo',)
+    assert ei.value.stack == ("foo",)
 
 
 def test_valueschema_normalizes_values():
@@ -592,7 +592,7 @@ def test_when_key_is_default():
     schema = deepcopy(choice_schema)
     schema["when_key_is"]["default_choice"] = "foo"
     assert normalize_schema(schema, {"foo_sibling": "hello"}) == {
-        "foo_sibling": "hello",
+        "foo_sibling": "hello"
     }
 
 


### PR DESCRIPTION
# Changes

This is a new feature that adds a `default_choice` to the `when_key_is` directive. You can use it like so:

```yaml
type: dict
when_key_is:
  key: type
  default_choice: foo
  choices:
    foo: {schema: {foo_sibling: {type: integer}}}
    bar: {schema: {bar_sibling: {type: string}}}
```

With this schema, the value can elide the `type` key and it will default to assuming that `type: foo`.

Note that this is different and orthogonal from specifying a `default` inside of a `type` key in the common `schema` in dict's schema. `default_choice` does not do any transformation of the document, so it won't insert the default value into the `type` field in the resulting document. You can still specify a `default` in the dict schema to do that.