### PR TITLE
Add support for selecting schemas based on contextual "tags", with various mechanisms to set those tags

### DIFF
--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -38,6 +38,11 @@ class Context(object):
         tags[tag] = value
         return attr.evolve(self, tags=tags)
 
+    def get_tag(self, tag):
+        if tag not in self.tags:
+            raise E.TagNotFound(tag, self.tags.keys(), self.stack)
+        return self.tags[tag]
+
 
 def normalize_dict(dict_schema, value, stack=(), allow_unknown=False):
     ctx = Context(stack=(), allow_unknown=allow_unknown)
@@ -199,9 +204,7 @@ class Normalizer(object):
         # This is a lot more simple and flexible than when_key_is
         # 1. it doesn't require this value to be a dict
         choice_key = directive_value["tag"]
-        if choice_key not in ctx.tags:
-            raise E.TagNotFound(choice_key, ctx.tags.keys(), ctx.stack)
-        chosen = ctx.tags[choice_key]
+        chosen = ctx.get_tag(choice_key)
         if chosen not in directive_value["choices"]:
             raise E.DisallowedValue(
                 chosen, directive_value["choices"].keys(), ctx.stack

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -199,6 +199,8 @@ class Normalizer(object):
         # This is a lot more simple and flexible than when_key_is
         # 1. it doesn't require this value to be a dict
         choice_key = directive_value["tag"]
+        if choice_key not in ctx.tags:
+            raise E.TagNotFound(choice_key, ctx.tags.keys(), ctx.stack)
         chosen = ctx.tags[choice_key]
         if chosen not in directive_value["choices"]:
             raise E.DisallowedValue(

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -183,7 +183,10 @@ class Normalizer(object):
         if not isinstance(directive_value, list):
             directive_value = [directive_value]
         for dv in directive_value:
-            ctx = ctx.set_tag(dv["tag_name"], value[dv["key"]])
+            if isinstance(dv, six.string_types):
+                ctx = ctx.set_tag(dv, value[dv])
+            else:
+                ctx = ctx.set_tag(dv["tag_name"], value[dv["key"]])
         return (value, ctx)
 
     @directive("choose_schema")

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -12,7 +12,7 @@ from . import errors as E
 __all__ = ["normalize_dict", "normalize_schema"]
 
 
-_NOT_SPECIFIED = object()
+_marker = object()
 
 
 @attr.s(frozen=True)
@@ -41,8 +41,8 @@ class Context(object):
         tags[tag] = value
         return attr.evolve(self, tags=tags)
 
-    def get_tag(self, tag, default=_NOT_SPECIFIED):
-        if default is _NOT_SPECIFIED and tag not in self.tags:
+    def get_tag(self, tag, default=_marker):
+        if default is _marker and tag not in self.tags:
             raise E.TagNotFound(tag, self.tags.keys(), self.stack)
         return self.tags.get(tag, default)
 
@@ -102,8 +102,6 @@ def _get_default(key, key_schema, doc, ctx):
                 raise E.DefaultSetterUnexpectedError(key, doc, e, ctx.stack)
     return _marker
 
-
-_marker = object()
 
 TYPES = {
     "none": type(None),
@@ -215,7 +213,7 @@ class Normalizer(object):
         # This is a lot more simple and flexible than when_key_is
         # 1. it doesn't require this value to be a dict
         choice_key = directive_value["tag"]
-        chosen = ctx.get_tag(choice_key, directive_value.get("default_choice", _NOT_SPECIFIED))
+        chosen = ctx.get_tag(choice_key, directive_value.get("default_choice", _marker))
         if chosen not in directive_value["choices"]:
             raise E.DisallowedValue(
                 chosen, directive_value["choices"].keys(), ctx.stack

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -196,7 +196,9 @@ class Normalizer(object):
                 elif "value" in dv:
                     val = dv["value"]
                 else:
-                    raise E.SimpleSchemaError(msg="`set_tag` must have `key` or `value`")
+                    raise E.SimpleSchemaError(
+                        msg="`set_tag` must have `key` or `value`"
+                    )
                 ctx = ctx.set_tag(dv["tag_name"], val)
         return (value, ctx)
 

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -191,7 +191,13 @@ class Normalizer(object):
             if isinstance(dv, six.string_types):
                 ctx = ctx.set_tag(dv, value[dv])
             else:
-                ctx = ctx.set_tag(dv["tag_name"], value[dv["key"]])
+                if "key" in dv:
+                    val = value[dv["key"]]
+                elif "value" in dv:
+                    val = dv["value"]
+                else:
+                    raise E.SimpleSchemaError(msg="`set_tag` must have `key` or `value`")
+                ctx = ctx.set_tag(dv["tag_name"], val)
         return (value, ctx)
 
     @directive("choose_schema")

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -178,8 +178,8 @@ class Normalizer(object):
             return _ShortCircuit(value)
         return (value, ctx)
 
-    @directive("hook_context")
-    def handle_hook_context(self, value, directive_value, ctx):
+    @directive("modify_context")
+    def handle_modify_context(self, value, directive_value, ctx):
         ctx = directive_value(value, ctx)
         return (value, ctx)
 

--- a/sureberus/constants.py
+++ b/sureberus/constants.py
@@ -1,0 +1,1 @@
+_marker = object()

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -9,6 +9,10 @@ class SchemaError(Exception):
         return self.__dict__
 
 
+class SimpleSchemaError(SchemaError):
+    msg = attr.ib()
+
+
 class SureError(Exception):
     def __str__(self):
         stack = "root"

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -185,7 +185,7 @@ class UnknownSchemaDirectives(SchemaError):
 
 @attr.s
 class TagNotFound(SureError):
-    fmt = "Tag {tag!r} not found (current tags: {tags!r}). Tags are set with `hook_context` or `set_tag` directives."
+    fmt = "Tag {tag!r} not found (current tags: {tags!r}). Tags are set with `modify_context` or `set_tag` directives."
     tag = attr.ib()
     tags = attr.ib()
     stack = attr.ib()

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -177,3 +177,11 @@ class CoerceUnexpectedError(SureError):
 class UnknownSchemaDirectives(SchemaError):
     fmt = "Unknown schema directives {directives!r}"
     directives = attr.ib()
+
+
+@attr.s
+class TagNotFound(SureError):
+    fmt = "Tag {tag!r} not found (current tags: {tags!r}). Tags are set with `hook_context` or `set_tag` directives."
+    tag = attr.ib()
+    tags = attr.ib()
+    stack = attr.ib()

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -2,6 +2,15 @@
 Utility functions that allow declaring schemas in nicer ways.
 """
 
+from .constants import _marker
+
+
+def when_tag_is(tag, choices, default_choice=_marker):
+    wti = {"tag": tag, "choices": choices, "default_choice": default_choice}
+    if default_choice is not _marker:
+        wti["default_choice"] = default_choice
+    return {"when_tag_is": wti}
+
 
 def mk(d, kw, **morekw):
     schema = {}
@@ -27,7 +36,7 @@ class _MISSING(object):
 def DictWhenKeyIs(key, choices, default_choice=_MISSING, **kwargs):
     when_key_is = {"key": key, "choices": choices}
     if default_choice is not _MISSING:
-        when_key_is['default_choice'] = default_choice
+        when_key_is["default_choice"] = default_choice
     return Dict(when_key_is=when_key_is, **kwargs)
 
 

--- a/test_sure.py
+++ b/test_sure.py
@@ -883,6 +883,26 @@ def test_set_tag_with_string():
         normalize_schema(schema, {"type": "S", "otherthing": True})
 
 
+def test_when_tag_is_default():
+    schema = S.Dict(
+        schema={
+            "type": S.String(required=False),
+            "otherthing": {
+                "when_tag_is": {
+                    "tag": "type",
+                    "choices": {"B": S.Boolean(), "S": S.String()},
+                    "default_choice": "B"
+                }
+            },
+        },
+    )
+
+    v = {"otherthing": True}
+    assert normalize_schema(schema, v) == v
+    with pytest.raises(E.BadType) as ei:
+        normalize_schema(schema, {"otherthing": "foo"})
+
+
 def test_set_tag_fixed_value():
     schema = S.Dict(
         set_tag={"tag_name": "type", "value": 33},

--- a/test_sure.py
+++ b/test_sure.py
@@ -857,6 +857,7 @@ def test_data_driven_context():
     with pytest.raises(E.BadType) as ei:
         normalize_schema(schema, {"type": "S", "otherthing": True})
 
+
 def test_set_tag_with_string():
     schema = S.Dict(
         set_tag="type",
@@ -886,10 +887,13 @@ def test_set_tag_fixed_value():
     schema = S.Dict(
         set_tag={"tag_name": "type", "value": 33},
         schema={
-            "foo": {"when_tag_is": {
-                "tag": "type", "choices": {32: S.String(), 33: S.Boolean()},
-            }}
-        }
+            "foo": {
+                "when_tag_is": {
+                    "tag": "type",
+                    "choices": {32: S.String(), 33: S.Boolean()},
+                }
+            }
+        },
     )
     v = {"foo": True}
     assert normalize_schema(schema, v) == v

--- a/test_sure.py
+++ b/test_sure.py
@@ -816,9 +816,11 @@ def test_contextual_schemas():
         schema={
             "type": S.String(),
             "otherthing": {
-                "choose_schema": lambda v, c: S.Boolean()
-                if c.get_tag("my_tag") == "bool"
-                else S.String()
+                "choose_schema": {
+                    "function": lambda v, c: (
+                        S.Boolean() if c.get_tag("my_tag") == "bool" else S.String()
+                    )
+                }
             },
         },
     )
@@ -839,10 +841,9 @@ def test_data_driven_context():
         schema={
             "type": S.String(),
             "otherthing": {
-                "when_tag_is": {
-                    "tag": "my_tag",
-                    "choices": {"B": S.Boolean(), "S": S.String()},
-                }
+                "choose_schema": S.when_tag_is(
+                    "my_tag", {"B": S.Boolean(), "S": S.String()}
+                )
             },
         },
     )
@@ -864,10 +865,9 @@ def test_set_tag_with_string():
         schema={
             "type": S.String(),
             "otherthing": {
-                "when_tag_is": {
-                    "tag": "type",
-                    "choices": {"B": S.Boolean(), "S": S.String()},
-                }
+                "choose_schema": S.when_tag_is(
+                    "type", {"B": S.Boolean(), "S": S.String()}
+                )
             },
         },
     )
@@ -888,11 +888,9 @@ def test_when_tag_is_default():
         schema={
             "type": S.String(required=False),
             "otherthing": {
-                "when_tag_is": {
-                    "tag": "type",
-                    "choices": {"B": S.Boolean(), "S": S.String()},
-                    "default_choice": "B",
-                }
+                "choose_schema": S.when_tag_is(
+                    "type", {"B": S.Boolean(), "S": S.String()}, default_choice="B"
+                )
             },
         }
     )
@@ -908,10 +906,9 @@ def test_set_tag_fixed_value():
         set_tag={"tag_name": "type", "value": 33},
         schema={
             "foo": {
-                "when_tag_is": {
-                    "tag": "type",
-                    "choices": {32: S.String(), 33: S.Boolean()},
-                }
+                "choose_schema": S.when_tag_is(
+                    "type", {32: S.String(), 33: S.Boolean()}
+                )
             }
         },
     )

--- a/test_sure.py
+++ b/test_sure.py
@@ -857,3 +857,27 @@ def test_data_driven_context():
     with pytest.raises(E.BadType) as ei:
         normalize_schema(schema, {"type": "S", "otherthing": True})
 
+def test_set_tag_with_string():
+    schema = S.Dict(
+        set_tag="type",
+        schema={
+            "type": S.String(),
+            "otherthing": {
+                "when_tag_is": {
+                    "tag": "type",
+                    "choices": {"B": S.Boolean(), "S": S.String()},
+                }
+            },
+        },
+    )
+
+    v = {"type": "B", "otherthing": True}
+    assert normalize_schema(schema, v) == v
+    with pytest.raises(E.BadType) as ei:
+        normalize_schema(schema, {"type": "B", "otherthing": "foo"})
+
+    v = {"type": "S", "otherthing": "fyoo"}
+    assert normalize_schema(schema, v) == v
+    with pytest.raises(E.BadType) as ei:
+        normalize_schema(schema, {"type": "S", "otherthing": True})
+

--- a/test_sure.py
+++ b/test_sure.py
@@ -817,7 +817,7 @@ def test_contextual_schemas():
             "type": S.String(),
             "otherthing": {
                 "choose_schema": lambda v, c: S.Boolean()
-                if c.tags["my_tag"] == "bool"
+                if c.get_tag("my_tag") == "bool"
                 else S.String()
             },
         },

--- a/test_sure.py
+++ b/test_sure.py
@@ -881,3 +881,17 @@ def test_set_tag_with_string():
     with pytest.raises(E.BadType) as ei:
         normalize_schema(schema, {"type": "S", "otherthing": True})
 
+
+def test_set_tag_fixed_value():
+    schema = S.Dict(
+        set_tag={"tag_name": "type", "value": 33},
+        schema={
+            "foo": {"when_tag_is": {
+                "tag": "type", "choices": {32: S.String(), 33: S.Boolean()},
+            }}
+        }
+    )
+    v = {"foo": True}
+    assert normalize_schema(schema, v) == v
+    with pytest.raises(E.BadType) as ei:
+        normalize_schema(schema, {"foo": "hey"})

--- a/test_sure.py
+++ b/test_sure.py
@@ -812,7 +812,7 @@ def test_when_key_is_direct_reference():
 
 def test_contextual_schemas():
     schema = S.Dict(
-        hook_context=lambda v, c: c.set_tag("my_tag", v["type"]),
+        modify_context=lambda v, c: c.set_tag("my_tag", v["type"]),
         schema={
             "type": S.String(),
             "otherthing": {

--- a/test_sure.py
+++ b/test_sure.py
@@ -891,10 +891,10 @@ def test_when_tag_is_default():
                 "when_tag_is": {
                     "tag": "type",
                     "choices": {"B": S.Boolean(), "S": S.String()},
-                    "default_choice": "B"
+                    "default_choice": "B",
                 }
             },
-        },
+        }
     )
 
     v = {"otherthing": True}


### PR DESCRIPTION
## Changes

This PR introduces the concept of "tags" on the Context object, which are key/value settings.

It also provides various new schema directives which make use of those tags.

1. `"set_tag": {"tag_name": "foo", "value": "bar"}` - this sets the tag `foo` to the fixed value `bar`.
2. `"set_tag": {"tag_name": "foo", "key": "abc"}` - this sets the tag `foo` to the value `obj["abc"]` -- so, it assumes that the current object being validated is a dict.
3. `"set_tag": "foo"` - this sets the tag `foo` to the value of `obj["foo"]` -- it's just a shorthand for the first form where the tag name and the dict key are identical.
4. `"hook_context": lambda value, context: context.set_tag("mytag", value[0])` - this sets the tag `mytag` to the value `value[0]`, so it assumes the value being validated is a list.

`hook_context` is the most general mechanism for setting tags -- `set_tag` is just a convenient, data-driven syntax for setting tags, but if you need to do something more fancy you can always use `hook_context`.

Those are all the directives which *set* tags. But what good are tags? This PR also introduces directives that *read* them to choose schemas.

4. `when_tag_is` -- this is identical to `when_key_is`, but it uses tags instead of looking up a key on the current object.
5. `"choose_schema": lambda value, context: schema1 if context.get_tag("foo") == "bar" else schema2`

Again, `choose_schema` is the more general mechanism for choosing a schema based on a tag -- it can do everything that `when_tag_is` can do, but `when_tag_is` can be expressed in simple data structures (which can potentially be serialized).


## What this is all about

The combination of the new directives (either `set_tag` or `hook_context`, combined with either `when_tag_is` or `choose_schema`) gives us the ability to *select schemas at a distance*.

In other words, while `when_key_is` allows you to take a value like `{"type": "foo", "foo_specific_key": "bar"}` and validate it in a way that selects a schema based on `foo`, the new mechanism allows you to do this in a deeply nested structure.

For example:

```json
{
    "type": "foo",
    "common": {...},
    "data_service": {
        "renderers": [
            {"foo_specific": "bar"}
        ]
    }
}
```

Let's assume that the `{"flavor": "bar"}` dict has a schema specific to `foo`. With these new directives, we can have a schema like the following:

```yaml
type: dict
set_tag: "type"
schema:
  type: foo
  common: {type: dict}
  data_service:
    type: dict
    schema:
      renderers:
        type: list
        schema:
          type: dict
          when_tag_is:
            tag: type
            choices:
              foo: {type: dict, schema: {foo_specific: {type: string}}
              bar: {type: dict, schema: {bar_specific: {type: integer}}
```

Notice in particular the `when_tag_is` directive deep inside the schema, while it is *referencing* a tag set by the very top of the schema -- so the `type` you choose at the top of the object is varying what schemas are used to validate the elements of the `renderers` list.