### PR TITLE
choose_schema should be the main directive for all schema-selection

### DIFF
--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -227,8 +227,6 @@ class Normalizer(object):
             )
 
     def _handle_when_tag_is(self, value, directive_value, ctx):
-        # This is a lot more simple and flexible than when_key_is
-        # 1. it doesn't require this value to be a dict
         choice_key = directive_value["tag"]
         chosen = ctx.get_tag(choice_key, directive_value.get("default_choice", _marker))
         if chosen not in directive_value["choices"]:
@@ -238,7 +236,11 @@ class Normalizer(object):
         subschema = directive_value["choices"][chosen]
         if isinstance(subschema, str):
             subschema = ctx.find_schema(subschema)
-        return _ShortCircuit(_normalize_schema(subschema, value, ctx))
+        new_schema = deepcopy(self.schema)
+        subschema = subschema.copy()
+        new_schema.update(subschema)
+        del new_schema["choose_schema"]
+        return _ShortCircuit(_normalize_schema(new_schema, value, ctx))
 
     @directive("when_key_is")
     def handle_when_key_is(self, value, directive_value, ctx):

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -288,7 +288,9 @@ class Normalizer(object):
             "The top-level `when_key_exists` directive is deprecated. Please use `choose_schema`.",
             DeprecationWarning,
         )
-        return self._handle_when_key_exists(value, directive_value, ctx, "when_key_exists")
+        return self._handle_when_key_exists(
+            value, directive_value, ctx, "when_key_exists"
+        )
 
     def _handle_when_key_exists(self, value, directive_value, ctx, directive_name):
         self.handle_type(value, "dict", ctx)

--- a/sureberus/constants.py
+++ b/sureberus/constants.py
@@ -1,1 +1,1 @@
-_marker = object()
+class _marker(object): pass

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -12,6 +12,13 @@ def when_tag_is(tag, choices, default_choice=_marker):
     return {"when_tag_is": wti}
 
 
+def when_key_is(key, choices, default_choice=_marker):
+    wki = {"key": key, "choices": choices, "default_choice": default_choice}
+    if default_choice is not _marker:
+        wki["default_choice"] = default_choice
+    return {"when_key_is": wki}
+
+
 def mk(d, kw, **morekw):
     schema = {}
     if d is not None:

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -6,17 +6,21 @@ from .constants import _marker
 
 
 def when_tag_is(tag, choices, default_choice=_marker):
-    wti = {"tag": tag, "choices": choices, "default_choice": default_choice}
+    wti = {"tag": tag, "choices": choices}
     if default_choice is not _marker:
         wti["default_choice"] = default_choice
     return {"when_tag_is": wti}
 
 
 def when_key_is(key, choices, default_choice=_marker):
-    wki = {"key": key, "choices": choices, "default_choice": default_choice}
+    wki = {"key": key, "choices": choices}
     if default_choice is not _marker:
         wki["default_choice"] = default_choice
     return {"when_key_is": wki}
+
+
+def when_key_exists(choices):
+    return {"when_key_exists": choices}
 
 
 def mk(d, kw, **morekw):

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -45,6 +45,9 @@ class _MISSING(object):
 
 
 def DictWhenKeyIs(key, choices, default_choice=_MISSING, **kwargs):
+    """
+    Deprecated. Pass `chooose_schema=when_key_is(...)` to `Dict`.
+    """
     when_key_is = {"key": key, "choices": choices}
     if default_choice is not _MISSING:
         when_key_is["default_choice"] = default_choice
@@ -52,6 +55,9 @@ def DictWhenKeyIs(key, choices, default_choice=_MISSING, **kwargs):
 
 
 def DictWhenKeyExists(choices, **kwargs):
+    """
+    Deprecated. Pass `chooose_schema=when_key_exists(...)` to `Dict`.
+    """
     return Dict(when_key_exists=choices, **kwargs)
 
 

--- a/test_sure.py
+++ b/test_sure.py
@@ -517,7 +517,8 @@ choice_schema_nested = S.Dict(
 
 equivalent_choice_schemas = [choice_schema, choice_schema_nested]
 
-@pytest.mark.parametrize('choice_schema', equivalent_choice_schemas)
+
+@pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
 def test_when_key_is(choice_schema):
     v = {"type": "foo", "foo_sibling": "bar"}
     assert normalize_schema(choice_schema, v) == v
@@ -525,13 +526,15 @@ def test_when_key_is(choice_schema):
     assert normalize_schema(choice_schema, v2) == v2
 
 
-def test_when_key_is_unknown():
+@pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
+def test_when_key_is_unknown(choice_schema):
     with pytest.raises(E.DisallowedValue) as ei:
         normalize_schema(choice_schema, {"type": "baz"})
     assert ei.value.stack == ("type",)
 
 
-def test_when_key_is_wrong_choice():
+@pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
+def test_when_key_is_wrong_choice(choice_schema):
     v = {"type": "foo", "bar_sibling": 37}
     with pytest.raises(E.UnknownFields):  # this could as well be E.DictFieldNotFound...
         normalize_schema(choice_schema, v)
@@ -551,7 +554,8 @@ def test_when_key_is_other_schema_directives():
     assert normalize_schema(schema, v2) == {"type": "bar", "bar_sibling": 33}
 
 
-def test_when_key_is_common_schema():
+@pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
+def test_when_key_is_common_schema(choice_schema):
     schema = deepcopy(choice_schema)
     schema["schema"] = {"common!": S.String()}
     with pytest.raises(E.DictFieldNotFound) as ei:

--- a/test_sure.py
+++ b/test_sure.py
@@ -505,7 +505,7 @@ choice_schema = S.DictWhenKeyIs(
     },
 )
 
-choice_schema_nested = S.Dict(
+wki_schema = S.Dict(
     choose_schema=S.when_key_is(
         "type",
         {
@@ -515,7 +515,15 @@ choice_schema_nested = S.Dict(
     )
 )
 
-equivalent_choice_schemas = [choice_schema, choice_schema_nested]
+
+ignore_wki_deprecation = pytest.mark.filterwarnings(
+    "ignore:.*when_key_is.*:DeprecationWarning"
+)
+
+equivalent_choice_schemas = [
+    pytest.param(choice_schema, marks=ignore_wki_deprecation),
+    wki_schema,
+]
 
 
 @pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
@@ -541,13 +549,13 @@ def test_when_key_is_wrong_choice(choice_schema):
 
 
 def test_when_key_is_other_schema_directives():
-    schema = deepcopy(choice_schema)
+    schema = deepcopy(wki_schema)
 
     def coerce(x):
         x["bar_sibling"] += 1
         return x
 
-    schema["when_key_is"]["choices"]["bar"]["coerce"] = coerce
+    schema["choose_schema"]["when_key_is"]["choices"]["bar"]["coerce"] = coerce
     v = {"type": "foo", "foo_sibling": "hi"}
     assert normalize_schema(schema, v) == v
     v2 = {"type": "bar", "bar_sibling": 32}
@@ -573,7 +581,8 @@ def test_when_key_is_common_schema(choice_schema):
     assert normalize_schema(schema, v) == v
 
 
-def test_when_key_is_coercions():
+@pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
+def test_when_key_is_coercions(choice_schema):
     """Coercions happen *before* when_key_is, so they can e.g.
     convert from a non-dict to a dict.
     """
@@ -591,22 +600,25 @@ def test_when_key_is_coercions():
     }
 
 
-def test_when_key_is_type_check():
+@pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
+def test_when_key_is_type_check(choice_schema):
     with pytest.raises(E.BadType) as ei:
         normalize_schema(choice_schema, "foo")
     assert ei.value.type_ == "dict"
     assert ei.value.value == "foo"
 
 
-def test_when_key_is_not_found():
+@pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
+def test_when_key_is_not_found(choice_schema):
+    print("but what IS choice schema", choice_schema)
     with pytest.raises(E.DictFieldNotFound) as ei:
         normalize_schema(choice_schema, {"foo_sibling": "hello"})
     assert ei.value.key == "type"
 
 
 def test_when_key_is_default():
-    schema = deepcopy(choice_schema)
-    schema["when_key_is"]["default_choice"] = "foo"
+    schema = deepcopy(wki_schema)
+    schema["choose_schema"]["when_key_is"]["default_choice"] = "foo"
     assert normalize_schema(schema, {"foo_sibling": "hello"}) == {
         "foo_sibling": "hello"
     }
@@ -619,28 +631,50 @@ choice_existence_schema = S.DictWhenKeyExists(
     }
 )
 
+wke_schema = S.Dict(
+    choose_schema=S.when_key_exists(
+        {
+            "image": {"schema": {"image": S.String(), "width": S.Integer()}},
+            "pattern": {"schema": {"pattern": S.Dict(), "color": S.String()}},
+        }
+    )
+)
 
-def test_when_key_exists():
+ignore_wke_deprecation = pytest.mark.filterwarnings(
+    "ignore:.*when_key_exists.*:DeprecationWarning"
+)
+
+equivalent_exists_schemas = [
+    pytest.param(choice_existence_schema, marks=ignore_wke_deprecation),
+    wke_schema,
+]
+
+
+@pytest.mark.parametrize("choice_existence_schema", equivalent_exists_schemas)
+def test_when_key_exists(choice_existence_schema):
     v = {"image": "foo", "width": 3}
     assert normalize_schema(choice_existence_schema, v) == v
     v = {"pattern": {}, "color": "red"}
     assert normalize_schema(choice_existence_schema, v) == v
 
 
-def test_when_key_exists_wrong_choice():
+@pytest.mark.parametrize("choice_existence_schema", equivalent_exists_schemas)
+def test_when_key_exists_wrong_choice(choice_existence_schema):
     v = {"image": "foo", "color": "red"}
     with pytest.raises(E.UnknownFields):  # this could as well be E.DictFieldNotFound...
         normalize_schema(choice_existence_schema, v)
 
 
-def test_when_key_exists_error_multiple_keys_exist():
+@pytest.mark.parametrize("choice_existence_schema", equivalent_exists_schemas)
+def test_when_key_exists_error_multiple_keys_exist(choice_existence_schema):
     v = {"image": "foo", "width": 3, "pattern": {}, "color": "red"}
     with pytest.raises(E.DisallowedField) as ei:
         normalize_schema(choice_existence_schema, v)
     assert {ei.value.field, ei.value.excluded} == {"image", "pattern"}
 
 
-def test_when_key_exists_NO_keys_exist():
+@pytest.mark.parametrize("choice_existence_schema", equivalent_exists_schemas)
+def test_when_key_exists_NO_keys_exist(choice_existence_schema):
     v = {"width": 30}
     with pytest.raises(E.ExpectedOneField) as ei:
         normalize_schema(choice_existence_schema, v)
@@ -648,13 +682,13 @@ def test_when_key_exists_NO_keys_exist():
 
 
 def test_when_key_exists_other_schema_directives():
-    schema = deepcopy(choice_existence_schema)
+    schema = deepcopy(wke_schema)
 
     def coerce(x):
         x["width"] += 1
         return x
 
-    schema["when_key_exists"]["image"]["coerce"] = coerce
+    schema["choose_schema"]["when_key_exists"]["image"]["coerce"] = coerce
 
     v = {"pattern": {}, "color": "red"}
     assert normalize_schema(schema, v) == v
@@ -662,7 +696,8 @@ def test_when_key_exists_other_schema_directives():
     assert normalize_schema(schema, v) == {"image": "foo", "width": 4}
 
 
-def test_when_key_exists_common_schema():
+@pytest.mark.parametrize("choice_existence_schema", equivalent_exists_schemas)
+def test_when_key_exists_common_schema(choice_existence_schema):
     schema = deepcopy(choice_existence_schema)
     schema["schema"] = {"common!": S.String()}
     with pytest.raises(E.DictFieldNotFound) as ei:
@@ -680,7 +715,8 @@ def test_when_key_exists_common_schema():
     assert normalize_schema(schema, v) == v
 
 
-def test_when_key_exists_coercions():
+@pytest.mark.parametrize("choice_existence_schema", equivalent_exists_schemas)
+def test_when_key_exists_coercions(choice_existence_schema):
     """Coercions happen *before* when_key_exists, so they can e.g.
     convert from a non-dict to a dict.
     """
@@ -695,7 +731,8 @@ def test_when_key_exists_coercions():
     assert normalize_schema(schema, "red") == {"pattern": {}, "color": "red"}
 
 
-def test_when_key_exists_type_check():
+@pytest.mark.parametrize("choice_existence_schema", equivalent_exists_schemas)
+def test_when_key_exists_type_check(choice_existence_schema):
     with pytest.raises(E.BadType) as ei:
         normalize_schema(choice_existence_schema, "foo")
     assert ei.value.type_ == "dict"
@@ -788,11 +825,13 @@ def test_recursive_schemas_inside_when_key_exists():
     schema = S.Dict(
         registry={
             "recursive": S.List(
-                schema=S.DictWhenKeyExists(
-                    {
-                        "g": {"schema": {"g": S.String(), "sts": "recursive"}},
-                        "ot": {"schema": {"ot": S.String()}},
-                    }
+                schema=S.Dict(
+                    choose_schema=S.when_key_exists(
+                        {
+                            "g": {"schema": {"g": S.String(), "sts": "recursive"}},
+                            "ot": {"schema": {"ot": S.String()}},
+                        }
+                    )
                 )
             )
         },
@@ -813,15 +852,17 @@ def test_recursive_schemas_inside_when_key_exists():
 
 
 def test_when_key_exists_direct_reference():
-    schema = S.DictWhenKeyExists(
-        {"key": "ref"}, registry={"ref": S.Dict(schema={"key": S.String()})}
+    schema = S.Dict(
+        registry={"ref": S.Dict(schema={"key": S.String()})},
+        choose_schema=S.when_key_exists({"key": "ref"}),
     )
     assert normalize_schema(schema, {"key": "foo"})
 
 
 def test_when_key_is_direct_reference():
-    schema = S.DictWhenKeyIs(
-        "type", {"foo": "ref"}, registry={"ref": S.Dict(schema={"key": S.String()})}
+    schema = S.Dict(
+        registry={"ref": S.Dict(schema={"key": S.String()})},
+        choose_schema=S.when_key_is("type", {"foo": "ref"}),
     )
     assert normalize_schema(schema, {"type": "foo", "key": "a string"})
 

--- a/test_sure.py
+++ b/test_sure.py
@@ -505,8 +505,20 @@ choice_schema = S.DictWhenKeyIs(
     },
 )
 
+choice_schema_nested = S.Dict(
+    choose_schema=S.when_key_is(
+        "type",
+        {
+            "foo": {"schema": {"foo_sibling": S.String()}},
+            "bar": {"schema": {"bar_sibling": S.Integer()}},
+        },
+    )
+)
 
-def test_when_key_is():
+equivalent_choice_schemas = [choice_schema, choice_schema_nested]
+
+@pytest.mark.parametrize('choice_schema', equivalent_choice_schemas)
+def test_when_key_is(choice_schema):
     v = {"type": "foo", "foo_sibling": "bar"}
     assert normalize_schema(choice_schema, v) == v
     v2 = {"type": "bar", "bar_sibling": 37}

--- a/test_sure.py
+++ b/test_sure.py
@@ -958,6 +958,22 @@ def test_when_tag_is_default():
         normalize_schema(schema, {"otherthing": "foo"})
 
 
+def test_when_tag_is_type_check():
+    with pytest.raises(E.BadType) as ei:
+        v = normalize_schema(
+            S.Dict(
+                set_tag={"tag_name": "mytag", "value": "hey"},
+                choose_schema=S.when_tag_is(
+                    "mytag", {"hey": {"schema": {"field": {"type": "string"}}}}
+                ),
+            ),
+            "foo",
+        )
+        print(v)
+    assert ei.value.type_ == "dict"
+    assert ei.value.value == "foo"
+
+
 def test_set_tag_fixed_value():
     schema = S.Dict(
         set_tag={"tag_name": "type", "value": 33},


### PR DESCRIPTION
## Changes

- add support for `when_key_exists` and `when_key_is` inside of `choose_schema`
- adds `when_key_exists` and `when_key_is` helpers to the `schema` module
- ⚠️ fixes a bug in the `when_tag_is` function introduced in #10, where `default_choice` would be a `_marker` when no default choice was passed, leading to incorrect error messages when the tag couldn't be found.
- implements "schema merging" for `when_tag_is` -- so that the schema outside of the `choose_schema` directive still takes effect, just like how `when_key_is` and `when_key_exists` work.
- deprecates the top-level `when_key_exists` and `when_key_is` directives.