### PR TITLE
More registries

### DIFF
--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -127,7 +127,7 @@ The directive value is a dictionary which must contain one of the following keys
 **type** Python callable `(value) -> new value`, OR a string naming a registered coerce function
 
 Call a Python function with the value to get a new one to use.
-Or, if the directive is a string, look up the registered coerce function to perform coercion.
+Or, if the directive is a string, look up the [registered coerce function](#coerce_registry) to perform coercion.
 By default, you can pass `"to_list"` or `"to_set"` to convert the value to a list or set, if the value is not already a list or set, respectively.
 
 It's important to note that this function is called *before* all other directives that might reject a value.
@@ -139,7 +139,7 @@ This is a good directive to use if you want to normalize invalid documents to a 
 **type** Python callable `(value) -> new value`, OR a string naming a registered coerce function
 
 Call a Python function with the value to get a new one to use, *after* all other validation.
-Or, if the directive is a string, look up the registered coerce function to perform coercion.
+Or, if the directive is a string, look up the [registered coerce function](#coerce_registry) to perform coercion.
 By default, you can pass `"to_list"` or `"to_set"` to convert the value to a list or set, if the value is not already a list or set, respectively.
 
 <div class="sureberus-info">
@@ -352,12 +352,21 @@ These are the types available:
 ## validator
 
 **Validation Directive**<br>
-**type** Python callable `(field, value, error_func) -> None`
+**type** Python callable `(field, value, error_func) -> None`, OR a string naming a registered validator.
 
 Invokes a Python function to validate the value.
+Or, if the directive is a string, look up the [registered validator function](#validator_registry) to perform coercion.
 The function should return None if the value is valid, otherwise it should call
 `error_func(field, "error message")`.
 
+## validator_registry
+
+**Meta Directive**<br>
+**type** `dict` of `str` (validator names) to Python callables
+
+This allows you to register functions with a name that can be used in the [`validator`](#validator) directive.
+Each key in the directive should be a name, and the value should be a Python function that acts like a `validator` function.
+Then you can pass the name of the registered function to `validator` to invoke the registered function.
 
 ## valueschema
 

--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -124,20 +124,41 @@ The directive value is a dictionary which must contain one of the following keys
 ## coerce
 
 **Transformation Directive**<br>
-**type** Python callable `(value) -> new value`
+**type** Python callable `(value) -> new value`, OR a string naming a registered coerce function
 
 Call a Python function with the value to get a new one to use.
+Or, if the directive is a string, look up the registered coerce function to perform coercion.
+By default, you can pass `"to_list"` or `"to_set"` to convert the value to a list or set, if the value is not already a list or set, respectively.
+
 It's important to note that this function is called *before* all other directives that might reject a value.
 This is a good directive to use if you want to normalize invalid documents to a form that can be considered valid.
 
 ## coerce_post
 
 **Transformation Directive**<br>
-**type** Python callable `(value) -> new value`
+**type** Python callable `(value) -> new value`, OR a string naming a registered coerce function
 
-Call a Python function with the value to get a new one to use.
+Call a Python function with the value to get a new one to use, *after* all other validation.
+Or, if the directive is a string, look up the registered coerce function to perform coercion.
+By default, you can pass `"to_list"` or `"to_set"` to convert the value to a list or set, if the value is not already a list or set, respectively.
+
+<div class="sureberus-info">
+
 Unlike `coerce`, this function is applied *after* all other directives,
 so it's allowed to return values that wouldn't validate according to other directives in your schema.
+
+</div>
+
+
+## coerce_registry
+
+**Meta Directive**<br>
+**type** `dict` of `str` (coerce names) to Python callables
+
+This allows you to register functions with a name that can be used in the [`coerce`](#coerce) and [`coerce_post`](#coerce_post) directives.
+Each key in the directive should be a name, and the value should be a Python function that takes a single argument and returns a new value,
+just like the functions you would normally pass to `coerce`.
+Then you can pass the name of the registered function to `coerce` or `coerce_post` to invoke the registered function.
 
 ## default_registry
 
@@ -145,9 +166,8 @@ so it's allowed to return values that wouldn't validate according to other direc
 **type** `dict` of `str` (setter names) to Python callables
 
 This allows you to register functions with a name that can be used in the `default_setter` directive of [field schemas](#schema-for-dicts).
-Each key in the directive should be a name, and the value should be a Python function that takes a single argument
-(the dictionary on which the default is being added)
-and returns a new value to be used when the key does not appear in the document.
+Each key in the directive should be a name, and the value should be a Python function that acts like a `default_setter` function.
+Then you can pass the name of the registered function to `default_setter` to invoke the registered function.
 
 ## modify_context
 

--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -307,6 +307,7 @@ Each value is a Sureberus schema that can have a few **extra** directives, speci
 * `required`: (`bool`) Indicates whether the field must be present.
 * `excludes`: (`list of strings`) Specifies a list of keys which *must not exist* on the dictionary for this schema to validate.
 * `default`: (object) A value to associate with the key in the resulting dict if the key was not present in the input.
+  If you want to default a field to an empty list or dict, do *not* use `default: []`. Instead use `default_setter: "list"`.
 * `default_setter`: (Python callable of `(dict) -> value`, OR a string)
   A Python function to call if the key was not present in the input.
   It is passed the dictionary, and its return value will be used as the default.

--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -139,6 +139,16 @@ Call a Python function with the value to get a new one to use.
 Unlike `coerce`, this function is applied *after* all other directives,
 so it's allowed to return values that wouldn't validate according to other directives in your schema.
 
+## default_registry
+
+**Meta Directive**<br>
+**type** `dict` of `str` (setter names) to Python callables
+
+This allows you to register functions with a name that can be used in the `default_setter` directive of [field schemas](#schema-for-dicts).
+Each key in the directive should be a name, and the value should be a Python function that takes a single argument
+(the dictionary on which the default is being added)
+and returns a new value to be used when the key does not appear in the document.
+
 ## modify_context
 
 **Meta Directive**<br>
@@ -267,8 +277,11 @@ Each value is a Sureberus schema that can have a few **extra** directives, speci
 * `required`: (`bool`) Indicates whether the field must be present.
 * `excludes`: (`list of strings`) Specifies a list of keys which *must not exist* on the dictionary for this schema to validate.
 * `default`: (object) A value to associate with the key in the resulting dict if the key was not present in the input.
-* `default_setter`: (Python callable of `(dict) -> value`) A Python function to call if the key was not present in the input.
+* `default_setter`: (Python callable of `(dict) -> value`, OR a string)
+  A Python function to call if the key was not present in the input.
   It is passed the dictionary, and its return value will be used as the default.
+  If default_setter is given a string, then it will be used to look up a setter that has been registered with [`default_registry`](#default_registry).
+  By default, you can pass `"list"`, `"dict"`, or `"set"` to set the default to empty lists, dicts, and sets.
 
 
 ## set_tag

--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -182,6 +182,16 @@ to later be used with [`choose_schema`](#choose_schema).
 See [Dynamically selecting schemas](./schema-selection.md) for more information.
 
 
+## modify_context_registry
+
+**Meta Directive**<br>
+**type** `dict` of `str` (modify_context names) to Python callables
+
+This allows you to register functions with a name that can be used in the [`modify_context`](#modify_context) directive.
+Each key in the directive should be a name, and the value should be a Python function that acts like a `modify_context` function.
+Then you can pass the name of the registered function to `modify_context` to invoke the registered function.
+
+
 ## keyschema
 
 **Meta Directive**<br>

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -65,6 +65,9 @@ class Context(object):
     def resolve_validator(self, validator):
         return self._resolve_registered(validator, self.validator_registry, "validator")
 
+    def resolve_modify_context(self, modify_context):
+        return self._resolve_registered(modify_context, self.modify_context_registry, "modify_context")
+
     def _resolve_registered(self, thing, registry, name):
         if isinstance(thing, six.string_types):
             if thing in registry:
@@ -255,7 +258,7 @@ class Normalizer(object):
 
     @directive("modify_context")
     def handle_modify_context(self, value, directive_value, ctx):
-        ctx = directive_value(value, ctx)
+        ctx = ctx.resolve_modify_context(directive_value)(value, ctx)
         return (value, ctx)
 
     @directive("set_tag")

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -220,7 +220,6 @@ class Normalizer(object):
 
     @directive("validator_registry")
     def handle_validator_registry(self, value, directive_value, ctx):
-        print("[RADIX] registering validator", directive_value)
         return (value, ctx.register_validators(directive_value))
 
     @directive("modify_context_registry")

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -191,3 +191,10 @@ class TagNotFound(SureError):
     tag = attr.ib()
     tags = attr.ib()
     stack = attr.ib()
+
+
+@attr.s
+class SetterNotFound(SureError):
+    fmt = "There is no registered default_settert named {setter}. See the `default_registry` directive."
+    setter = attr.ib()
+    stack = attr.ib()

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -194,7 +194,8 @@ class TagNotFound(SureError):
 
 
 @attr.s
-class SetterNotFound(SureError):
-    fmt = "There is no registered default_settert named {setter}. See the `default_registry` directive."
+class RegisteredFunctionNotFound(SureError):
+    fmt = "There is no registered {registry_name} function named {setter}. See the `{registry_name}_registry` directive."
     setter = attr.ib()
+    registry_name = attr.ib()
     stack = attr.ib()

--- a/test_sure.py
+++ b/test_sure.py
@@ -414,6 +414,21 @@ def test_coerce():
     assert normalize_schema(schema, 33) == [33]
 
 
+def test_coerce_registry():
+    schema = {"coerce_registry": {"foo": lambda inp: inp + 3}, "coerce": "foo"}
+    assert normalize_schema(schema, 100) == 103
+
+
+def test_coerce_registered_defaults():
+    schema = {"coerce": "to_list"}
+    assert normalize_schema(schema, 100) == [100]
+    assert normalize_schema(schema, [100]) == [100]
+
+    schema = {"coerce": "to_set"}
+    assert normalize_schema(schema, 100) == {100}
+    assert normalize_schema(schema, {100}) == {100}
+
+
 def test_coerce_post_basic():
     def _to_list(item):
         if isinstance(item, list):
@@ -423,6 +438,20 @@ def test_coerce_post_basic():
 
     schema = {"coerce_post": _to_list}
     assert normalize_schema(schema, 33) == [33]
+
+def test_coerce_post_registry():
+    schema = {"coerce_registry": {"foo": lambda inp: inp + 3}, "coerce_post": "foo"}
+    assert normalize_schema(schema, 100) == 103
+
+
+def test_coerc_post_registered_defaults():
+    schema = {"coerce_post": "to_list"}
+    assert normalize_schema(schema, 100) == [100]
+    assert normalize_schema(schema, [100]) == [100]
+
+    schema = {"coerce_post": "to_set"}
+    assert normalize_schema(schema, 100) == {100}
+    assert normalize_schema(schema, {100}) == {100}
 
 
 def test_coerce_post_after_children():

--- a/test_sure.py
+++ b/test_sure.py
@@ -960,6 +960,16 @@ def test_contextual_schemas():
     with pytest.raises(E.BadType) as ei:
         normalize_schema(schema, {"type": "nope", "otherthing": True})
 
+def test_modify_context_registry():
+    schema = dict(
+        modify_context_registry={
+            "modc": lambda v, c: c.set_tag("cool", "thing"),
+        },
+        modify_context="modc",
+        schema={"choose_schema": S.when_tag_is("cool", {"thing": S.String()})}
+    )
+    assert normalize_schema(schema, "heya")
+
 
 def test_data_driven_context():
     schema = S.Dict(

--- a/test_sure.py
+++ b/test_sure.py
@@ -180,6 +180,31 @@ def test_default_setter():
     }
 
 
+def test_default_setter_registered():
+    schema = S.Dict(
+        default_registry={"foobar": lambda doco: doco["required"] + 1},
+        schema={
+            "required": S.Integer(),
+            "incremented": S.Integer(default_setter="foobar"),
+        },
+    )
+    assert normalize_schema(schema, {"required": 3}) == {
+        "required": 3,
+        "incremented": 4,
+    }
+
+
+def test_default_default_setters():
+    schema = S.Dict(
+        schema={
+            "list": S.List(default_setter="list"),
+            "dict": S.Dict(default_setter="dict"),
+            "set": S.Dict(default_setter="set"),
+        }
+    )
+    assert normalize_schema(schema, {}) == {"list": [], "dict": {}, "set": set()}
+
+
 def test_normalize_schema():
     assert normalize_schema(S.Integer(), 3)
 

--- a/test_sure.py
+++ b/test_sure.py
@@ -439,6 +439,7 @@ def test_coerce_post_basic():
     schema = {"coerce_post": _to_list}
     assert normalize_schema(schema, 33) == [33]
 
+
 def test_coerce_post_registry():
     schema = {"coerce_registry": {"foo": lambda inp: inp + 3}, "coerce_post": "foo"}
     assert normalize_schema(schema, 100) == 103
@@ -490,6 +491,20 @@ def test_validator_error():
     schema = {"key": {"validator": val}}
     with pytest.raises(E.CustomValidatorError) as ei:
         assert normalize_dict(schema, {"key": "hi"}) == {"key": "hi"}
+    assert ei.value.field == "key"
+    assert ei.value.msg == "heyo"
+
+
+def test_validator_registry():
+    def val(field, value, error):
+        error(field, "heyo")
+
+    schema = {
+        "validator_registry": {"non1": val},
+        "schema": {"key": {"validator": "non1"}},
+    }
+    with pytest.raises(E.CustomValidatorError) as ei:
+        assert normalize_schema(schema, {"key": "hi"}) == {"key": "hi"}
     assert ei.value.field == "key"
     assert ei.value.msg == "heyo"
 


### PR DESCRIPTION

Fixes #14.

## Changes

Introduce several new directives that define *registries* of Python functions, which allows use of registered names in various directives instead of directly including Python functions in the schema at the point of use.

* `coerce_registry` allows registering named functions for `coerce` and `coerce_post`
  * by default, `to_list` and `to_set` are registered, to wrap a value in a list or set if it's not already a list or set.
* `default_registry` allows registering named functions for `default_setter`
  * by default, `list`, `dict`, and `set` are registered, to produce empty data structures
* `modify_context_registry` allows registering named functions for `modify_context`
* `validator_registry` allows registering named functions for `validator`

## Why?

The point of this is to make it much easier to define schemas in *pure data*, potentially even storing them as YAML files in your repo. By allowing *registering* these Python functions at a higher level, it allows the body of the schemas to be "plain old Python objects" instead of needing to inline Python function.

e.g.

```python
schema_body = yaml.load(open("myschema.yaml").read())
myschema = {
  "coerce_registry": {"plus1": lambda value: value + 1},
  "registry": {"schema_body": schema_body},
  "schema_ref": "schema_body",
}
```

Here we are reading a schema from a file named `myschema.yaml`. This schema can potentially have directives like `coerce: "plus1"` sprinkled throughout it, instead of putting `lambda x: x+1` directly into the schema body (which wouldn't be representable in YAML!). then we register the `plus1` coerce function in our Python code and embed the schema from `myschema.yaml` inside (the `registry` / `schema_ref` trick to embed the schema is a bit ugly, a better syntax for that is TBD).

