### PR TITLE
Down with schema

### DIFF
--- a/doc/src/python-schema.md
+++ b/doc/src/python-schema.md
@@ -10,9 +10,9 @@ newline/indent-based line wrapping:
 myschema = {
     'type': 'dict',
     'anyof': [
-        {'schema': {'gradient': {'type': 'string'}}},
+        {'fields': {'gradient': {'type': 'string'}}},
         {
-            'schema': {
+            'fields': {
                 'image': {'type': 'string'},
                 'opacity': {'type': 'integer', 'default': 100},
             }
@@ -25,11 +25,11 @@ And here is a `sureberus.schema`-based schema, using the same line-wrapping
 rules:
 
 ```python
-from sureberus.schema import Dict, SubSchema, String, Integer
+from sureberus.schema import Dict, String, Integer
 myschema = Dict(
     anyof=[
-        SubSchema(gradient=String()),
-        SubSchema(image=String(), opacity=Integer(default=100))
+        dict(gradient=String()),
+        dict(image=String(), opacity=Integer(default=100))
     ]
 )
 ```

--- a/doc/src/schema-registries.md
+++ b/doc/src/schema-registries.md
@@ -11,7 +11,7 @@ For example, here is a schema that validates any nested list of strings:
     "registry": {
         "nested_list": {
             "type": "list",
-            "schema": {
+            "elements": {
                 "anyof": [
                     {"type": "string"},
                     "nested_list",
@@ -20,7 +20,7 @@ For example, here is a schema that validates any nested list of strings:
         }
     },
     "type": "dict",
-    "schema": {"things": "nested_list"},
+    "fields": {"things": "nested_list"},
 }
 ```
 
@@ -39,7 +39,7 @@ exactly the same level, for example:
     "registry": {
         "nested_list": {
             "type": "list",
-            "schema": {"anyof": [{"type": "integer"}, "nested_list"]}
+            "elements": {"anyof": [{"type": "integer"}, "nested_list"]}
         }
     },
     "schema_ref": "nested_list",

--- a/doc/src/schema-selection.md
+++ b/doc/src/schema-selection.md
@@ -29,10 +29,10 @@ choose_schema:
     key: "type"
     choices:
       "elephant":
-        schema:
+        fields:
           "trunk_length": {"type": "integer"}
       "eagle":
-        schema:
+        fields:
           "wingspan": {"type": "integer"}
 ```
 
@@ -56,11 +56,11 @@ type: dict
 choose_schema:
   when_key_exists:
     "image_url":
-      schema:
+      fields:
         "image_url": {"type": "string"}
         "width": {"type": "integer"}
     "color":
-      schema:
+      fields:
         "color": {"type": "string"}
 ```
 
@@ -113,23 +113,24 @@ Here's an example of a schema that can parse our sample data, using the Python s
 ```python
 schema = S.Dict(
   set_tag="type",
-  schema={
+  fields={
     "type": S.String(),
     "common": S.Dict(),
     "data_service": S.Dict(
-      schema={
+      fields={
         "renderers": S.List(
-          schema=S.Dict(
+          elements=S.Dict(
             choose_schema=S.when_tag_is(
               "type",
               {
-                "foo": S.Dict(schema={"foo_specific": S.String()}),
-                "bar": S.Dict(schema={"bar_specific": S.Integer()}),
+                "foo": S.Dict(fields={"foo_specific": S.String()}),
+                "bar": S.Dict(fields={"bar_specific": S.Integer()}),
               })))})})
 ```
 
 Here we're using the `set_tag` directive with its shorthand for specifying a tag name that will be equivalent to the name of the key to look up in the dict.
 When Sureberus applies this schema to the top-level `dict`, it looks for the key named `type`, and stores its value in the Context under a tag named `type`.
 Then, deeper inside this schema, we make use of the `choose_schema` directive with the `when_tag_is` sub-directive.
-We pass the tag name `type` here, so it looks up the value associated with the `type` tag in the Context, and uses that to select the corresponding schema defined in the choices passed to `when_tag_is`.
+We pass the tag name `type` here, so it looks up the value associated with the `type` tag in the Context,
+and uses that to select the corresponding schema defined in the choices passed to `when_tag_is`.
 Thus, when the top-level dict has `"type": "foo"`, Sureberus will ultimately select the schema containing `"foo_specific"`.

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -340,8 +340,8 @@ class Normalizer(object):
         # since we can figure out exactly which values it should allow based
         # on what's in the `when_key_is`.
         allowed_choices = list(directive_value["choices"].keys())
-        if choice_key not in new_schema.setdefault("schema", {}):
-            new_schema["schema"][choice_key] = {"allowed": allowed_choices}
+        if choice_key not in new_schema.setdefault("fields", {}):
+            new_schema["fields"][choice_key] = {"allowed": allowed_choices}
         if choice_key not in value:
             if "default_choice" in directive_value:
                 chosen_type = directive_value["default_choice"]
@@ -357,7 +357,12 @@ class Normalizer(object):
         if isinstance(subschema, str):
             subschema = ctx.find_schema(subschema)
         subschema = subschema.copy()
-        new_schema["schema"].update(subschema.pop("schema"))
+        # this is some shenanigans to support both "fields" and "schema"
+        fields = new_schema.pop("schema", {}).copy()
+        fields.update(new_schema.pop("fields", {}))
+        new_schema["fields"] = fields
+        new_schema["fields"].update(subschema.pop("schema", {}))
+        new_schema["fields"].update(subschema.pop("fields", {}))
         new_schema.update(subschema)
         # Make sure that the new schema does not include the same `choose_schema`
         # or `when_key_is` directive, to avoid infinite recursion
@@ -392,7 +397,12 @@ class Normalizer(object):
         if isinstance(subschema, str):
             subschema = ctx.find_schema(subschema)
         subschema = subschema.copy()
-        new_schema.setdefault("schema", {}).update(subschema.pop("schema"))
+        # this is some shenanigans to support both "fields" and "schema"
+        fields = new_schema.pop("schema", {}).copy()
+        fields.update(new_schema.pop("fields", {}))
+        new_schema["fields"] = fields
+        new_schema["fields"].update(subschema.pop("schema", {}))
+        new_schema["fields"].update(subschema.pop("fields", {}))
         new_schema.update(subschema)
         # Make sure that the new schema does not include the same `choose_schema`
         # or `when_key_is` directive, to avoid infinite recursion

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -318,6 +318,11 @@ class Normalizer(object):
             subschema = ctx.find_schema(subschema)
         new_schema = deepcopy(self.schema)
         subschema = subschema.copy()
+        if "fields" in new_schema or "fields" in subschema:
+            # merge in fields.
+            # I wish I didn't need to do this, but it's the only sensible way I can figure out
+            # to support both common and tag-specific fields in the same schema.
+            new_schema.setdefault("fields", {}).update(subschema.pop("fields", {}))
         new_schema.update(subschema)
         del new_schema["choose_schema"]
         return _ShortCircuit(_normalize_schema(new_schema, value, ctx))

--- a/test_sure.py
+++ b/test_sure.py
@@ -595,6 +595,16 @@ wki_schema = S.Dict(
     )
 )
 
+wki_schema_fields = S.Dict(
+    choose_schema=S.when_key_is(
+        "type",
+        {
+            "foo": {"fields": {"foo_sibling": S.String()}},
+            "bar": {"fields": {"bar_sibling": S.Integer()}},
+        },
+    )
+)
+
 
 ignore_wki_deprecation = pytest.mark.filterwarnings(
     "ignore:.*when_key_is.*:DeprecationWarning"
@@ -603,6 +613,7 @@ ignore_wki_deprecation = pytest.mark.filterwarnings(
 equivalent_choice_schemas = [
     pytest.param(choice_schema, marks=ignore_wki_deprecation),
     wki_schema,
+    wki_schema_fields,
 ]
 
 
@@ -643,9 +654,10 @@ def test_when_key_is_other_schema_directives():
 
 
 @pytest.mark.parametrize("choice_schema", equivalent_choice_schemas)
-def test_when_key_is_common_schema(choice_schema):
+@pytest.mark.parametrize("fields_name", ["schema", "fields"])
+def test_when_key_is_common_schema(choice_schema, fields_name):
     schema = deepcopy(choice_schema)
-    schema["schema"] = {"common!": S.String()}
+    schema[fields_name] = {"common!": S.String()}
     with pytest.raises(E.DictFieldNotFound) as ei:
         v = {"type": "foo", "foo_sibling": "hi"}
         normalize_schema(schema, v)
@@ -720,6 +732,15 @@ wke_schema = S.Dict(
     )
 )
 
+wke_schema_fields = S.Dict(
+    choose_schema=S.when_key_exists(
+        {
+            "image": {"fields": {"image": S.String(), "width": S.Integer()}},
+            "pattern": {"fields": {"pattern": S.Dict(), "color": S.String()}},
+        }
+    )
+)
+
 ignore_wke_deprecation = pytest.mark.filterwarnings(
     "ignore:.*when_key_exists.*:DeprecationWarning"
 )
@@ -727,6 +748,7 @@ ignore_wke_deprecation = pytest.mark.filterwarnings(
 equivalent_exists_schemas = [
     pytest.param(choice_existence_schema, marks=ignore_wke_deprecation),
     wke_schema,
+    wke_schema_fields,
 ]
 
 

--- a/test_sure.py
+++ b/test_sure.py
@@ -1100,3 +1100,14 @@ def test_set_tag_fixed_value():
     assert normalize_schema(schema, v) == v
     with pytest.raises(E.BadType) as ei:
         normalize_schema(schema, {"foo": "hey"})
+
+
+def test_when_tag_is_merge_fields():
+    schema = S.Dict(
+        set_tag={"tag_name": "thetag", "value": "theval"},
+        fields={"common": S.Integer(default=0)},
+        choose_schema=S.when_tag_is(
+            "thetag", {"theval": {"fields": {"theval_field": S.Integer(default=1)}}}
+        ),
+    )
+    assert normalize_schema(schema, {}) == {"common": 0, "theval_field": 1}

--- a/test_sure.py
+++ b/test_sure.py
@@ -15,6 +15,15 @@ def test_dict_of_int():
     assert normalize_dict(id_int, sample) == sample
 
 
+@pytest.mark.parametrize(
+    "schema", [S.Dict(schema={"foo": S.Integer()}), S.Dict(fields={"foo": S.Integer()})]
+)
+def test_fields(schema):
+    assert normalize_schema(schema, {"foo": 3}) == {"foo": 3}
+    with pytest.raises(E.BadType):
+        normalize_schema(schema, {"foo": "3"})
+
+
 def test_valueschema():
     schema = S.Dict(allow_unknown=True, valueschema=S.Integer())
     assert normalize_schema(schema, {"foo": 3, 52: 52}) == {"foo": 3, 52: 52}
@@ -348,8 +357,10 @@ def test_list():
     assert normalize_schema(schema, val) == val
 
 
-def test_list_schema():
-    schema = S.List(schema=S.Integer())
+@pytest.mark.parametrize(
+    "schema", [S.List(schema=S.Integer()), S.List(elements=S.Integer())]
+)
+def test_list_schema(schema):
     val = [1, 2, 3]
     assert normalize_schema(schema, val) == val
 
@@ -960,13 +971,12 @@ def test_contextual_schemas():
     with pytest.raises(E.BadType) as ei:
         normalize_schema(schema, {"type": "nope", "otherthing": True})
 
+
 def test_modify_context_registry():
     schema = dict(
-        modify_context_registry={
-            "modc": lambda v, c: c.set_tag("cool", "thing"),
-        },
+        modify_context_registry={"modc": lambda v, c: c.set_tag("cool", "thing")},
         modify_context="modc",
-        schema={"choose_schema": S.when_tag_is("cool", {"thing": S.String()})}
+        schema={"choose_schema": S.when_tag_is("cool", {"thing": S.String()})},
     )
     assert normalize_schema(schema, "heya")
 


### PR DESCRIPTION
Fixes #7 

## Changes

Introduces two new directives:

- `elements`, which applies a schema to each element in a list
- `fields`, which defines fields for dict values

these are basically equivalent to the `schema` directive, but without the weird runtime type checking behavior that `schema` has. And they're just much clearer names -- when we talk about "schemas" it should be obvious what we mean.