### PR TITLE
add a coerce_with_context directive

### DIFF
--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -169,7 +169,7 @@ so it's allowed to return values that wouldn't validate according to other direc
 ## coerce_with_context
 
 **Transformation Directive**<br>
-**type** Python callable `(value, Context) -> new value`, OR a string naming a registered coerce function
+**type** Python callable `(value, Context) -> new value`, OR a string naming a registered coerce function<br>
 **Introduced in** Sureberus 0.12.0
 
 Call a Python function with the value *and the Context* to calculate a replacement.
@@ -182,7 +182,7 @@ The function can access tags stored in the context with the `Context.get_tag(tag
 ## coerce_post_with_context
 
 **Transformation Directive**<br>
-**type** Python callable `(value, Context) -> new value`, OR a string naming a registered coerce function
+**type** Python callable `(value, Context) -> new value`, OR a string naming a registered coerce function<br>
 **Introduced in** Sureberus 0.12.0
 
 Identical to [`coerce`](#coerce_with_context), but runs after all validation.

--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -166,6 +166,18 @@ so it's allowed to return values that wouldn't validate according to other direc
 
 </div>
 
+## coerce_with_context
+
+**Transformation Directive**<br>
+**type** Python callable `(value) -> new value`, OR a string naming a registered coerce function
+**Introduced in** Sureberus 0.12.0
+
+Call a Python function with the value **and the Context** to calculate a replacement.
+Or, if the directive is a string, look up the [registered coerce function](#coerce_registry) to perform coercion.
+
+This can be used in tandem with [`set_tag`](#set_tag) or [`modify_context`](#modify_context) to pass data to transformers that are run on deeper parts of the document.
+The function can access tags stored in the context with the `Context.get_tag(tag_name)` method.
+
 
 ## coerce_registry
 

--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -169,10 +169,10 @@ so it's allowed to return values that wouldn't validate according to other direc
 ## coerce_with_context
 
 **Transformation Directive**<br>
-**type** Python callable `(value) -> new value`, OR a string naming a registered coerce function
+**type** Python callable `(value, Context) -> new value`, OR a string naming a registered coerce function
 **Introduced in** Sureberus 0.12.0
 
-Call a Python function with the value **and the Context** to calculate a replacement.
+Call a Python function with the value *and the Context* to calculate a replacement.
 Or, if the directive is a string, look up the [registered coerce function](#coerce_registry) to perform coercion.
 
 This can be used in tandem with [`set_tag`](#set_tag) or [`modify_context`](#modify_context) to pass data to transformers that are run on deeper parts of the document.

--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -179,6 +179,15 @@ This can be used in tandem with [`set_tag`](#set_tag) or [`modify_context`](#mod
 The function can access tags stored in the context with the `Context.get_tag(tag_name)` method.
 
 
+## coerce_post_with_context
+
+**Transformation Directive**<br>
+**type** Python callable `(value, Context) -> new value`, OR a string naming a registered coerce function
+**Introduced in** Sureberus 0.12.0
+
+Identical to [`coerce`](#coerce_with_context), but runs after all validation.
+
+
 ## coerce_registry
 
 **Meta Directive**<br>

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -258,13 +258,13 @@ class Normalizer(object):
             raise E.CoerceUnexpectedError(directive, value, e, ctx.stack)
 
     @directive("coerce_with_context")
-    def handle_coerce_with_context(self, value, directive_value, ctx):
+    def handle_coerce_with_context(self, value, directive_value, ctx, directive="coerce_with_context"):
         try:
             return (ctx.resolve_coerce(directive_value)(value, ctx), ctx)
         except E.SureError:
             raise
         except Exception as e:
-            raise E.CoerceUnexpectedError("coerce_with_context", value, e, ctx.stack)
+            raise E.CoerceUnexpectedError(directive, value, e, ctx.stack)
 
     @directive("nullable")
     def handle_nullable(self, value, directive_value, ctx):
@@ -584,6 +584,10 @@ class Normalizer(object):
         values or list elements).
         """
         return self.handle_coerce(value, directive_value, ctx, directive="coerce_post")
+
+    @directive("coerce_post_with_context")
+    def handle_coerce_post_with_context(self, value, directive_value, ctx):
+        return self.handle_coerce_with_context(value, directive_value, ctx, directive="coerce_post_with_context")
 
 
 def _merge_schemas(schema1, schema2):

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -249,13 +249,22 @@ class Normalizer(object):
         return (value, ctx.set_allow_unknown(directive_value))
 
     @directive("coerce")
-    def handle_coerce(self, value, directive_value, ctx):
+    def handle_coerce(self, value, directive_value, ctx, directive="coerce"):
         try:
             return (ctx.resolve_coerce(directive_value)(value), ctx)
         except E.SureError:
             raise
         except Exception as e:
-            raise E.CoerceUnexpectedError(value, e, ctx.stack)
+            raise E.CoerceUnexpectedError(directive, value, e, ctx.stack)
+
+    @directive("coerce_with_context")
+    def handle_coerce_with_context(self, value, directive_value, ctx):
+        try:
+            return (ctx.resolve_coerce(directive_value)(value, ctx), ctx)
+        except E.SureError:
+            raise
+        except Exception as e:
+            raise E.CoerceUnexpectedError("coerce_with_context", value, e, ctx.stack)
 
     @directive("nullable")
     def handle_nullable(self, value, directive_value, ctx):
@@ -574,7 +583,7 @@ class Normalizer(object):
         done (most importantly, after any normalization done in child dict
         values or list elements).
         """
-        return self.handle_coerce(value, directive_value, ctx)
+        return self.handle_coerce(value, directive_value, ctx, directive="coerce_post")
 
 
 def _merge_schemas(schema1, schema2):

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -174,7 +174,8 @@ class ValidatorUnexpectedError(SureError):
 
 @attr.s
 class CoerceUnexpectedError(SureError):
-    fmt = "coerce failed with value {value!r}. Exception: {exception}"
+    fmt = "{coerce_directive} failed with value {value!r}. Exception: {exception}"
+    coerce_directive = attr.ib()
     value = attr.ib()
     exception = attr.ib()
     stack = attr.ib()

--- a/test_sure.py
+++ b/test_sure.py
@@ -523,6 +523,23 @@ def test_coerce_with_context_errors_indicate_which_directive():
     assert ei.value.coerce_directive == "coerce_with_context"
 
 
+def test_coerce_post_with_context_is_a_post():
+    def validator(f, v, e):
+        if v is not None:
+            e(f, "MUST BE NONE")
+
+    def coercer(v, c):
+        return c.get_tag("mytag")
+
+    schema = {
+        "validator": validator,
+        "coerce_post_with_context": coercer,
+        "set_tag": {"tag_name": "mytag", "value": "foo"},
+    }
+
+    assert normalize_schema(schema, None) == "foo"
+
+
 def test_validator():
     called = []
 


### PR DESCRIPTION
This PR adds two new directives, `coerce_with_context` and `coerce_post_with_context`, which are identical to the existing `coerce*` directives except that they also pass the current Context to the coercer function.

This allows the coerce function to take advantage of tags, which means that there is now a much easier way to "thread" data down into transformation functions that run on deep parts of the document.

This PR also makes the `CoerceUnexpectedError` exception include the directive that triggered the error, since there are now four different directives that can cause this error (`coerce`, `coerce_post`, `coerce_with_context`, and `coerce_post_with_context`), and if you had multiple of them in the same schema, it might be unclear what the source of the error is.