### PR TITLE
BACKWARDS-INCOMPATIBLE: applying schemas to defaulted values

### DIFF
--- a/doc/src/directives.md
+++ b/doc/src/directives.md
@@ -748,6 +748,7 @@ These are the types available:
     "float": (float,) + six.integer_types,
     "number": (float,) + six.integer_types,
     "dict": dict,
+    "set": set,
     "list": list,
     "string": six.string_types,
     "boolean": bool,

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -143,6 +143,8 @@ def _normalize_dict(dict_schema, value, ctx):
             new_dict[new_key] = value[key]
         if new_key in new_dict:
             new_dict[new_key] = _normalize_schema(
+                # we push the *original* key onto the stack so users still see error
+                # messages in terms of their actual input
                 key_schema, new_dict[new_key], ctx.push_stack(key)
             )
             excludes = key_schema.get("excludes", [])

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -137,11 +137,13 @@ def _normalize_dict(dict_schema, value, ctx):
             replacement = _get_default(key, key_schema, value, ctx)
             if replacement is not _marker:
                 new_dict[new_key] = replacement
-            elif key_schema.get("required", False) == True:
+            elif key_schema.get("required", False):
                 raise E.DictFieldNotFound(key, value=value, stack=ctx.stack)
-        if key in value:
+        else:
+            new_dict[new_key] = value[key]
+        if new_key in new_dict:
             new_dict[new_key] = _normalize_schema(
-                key_schema, value[key], ctx.push_stack(key)
+                key_schema, new_dict[new_key], ctx.push_stack(key)
             )
             excludes = key_schema.get("excludes", [])
             if not isinstance(excludes, list):
@@ -179,6 +181,7 @@ TYPES_BY_PRECEDENCE = [
     ),  # cerberus documentation lies: integers are also considered floats.
     ("number", (float,) + six.integer_types),
     ("dict", dict),
+    ("set", set),
     ("list", list),
     ("string", six.string_types),
     ("boolean", bool),

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -87,3 +87,7 @@ def Boolean(required=True, **kwargs):
 
 def List(required=True, _d=None, **kwargs):
     return mk(_d, kwargs, type="list", required=required)
+
+
+def Set(**kwargs):
+    return mk(None, kwargs, type="set")

--- a/test_sure.py
+++ b/test_sure.py
@@ -208,10 +208,21 @@ def test_default_default_setters():
         schema={
             "list": S.List(default_setter="list"),
             "dict": S.Dict(default_setter="dict"),
-            "set": S.Dict(default_setter="set"),
+            "set": S.Set(default_setter="set"),
         }
     )
     assert normalize_schema(schema, {}) == {"list": [], "dict": {}, "set": set()}
+
+
+def test_default_then_normalized():
+    schema = S.Dict(
+        fields={
+            "subdict": S.Dict(
+                default_setter="dict", fields={"otherthing": S.Integer(default=0)}
+            )
+        }
+    )
+    assert normalize_schema(schema, {}) == {"subdict": {"otherthing": 0}}
 
 
 def test_normalize_schema():


### PR DESCRIPTION
This PR changes the behavior of Sureberus so that schemas are applied to values even when the values originate as defaults.

This allows for situations such as:

```yaml
type: dict
fields:
  foo:
    type: dict
    default_setter: dict
    fields:
      bar: {type: integer, default: 0}
```

which when applied to `{}`, will now result in `{'foo': {'bar': 0}}`, when it would previously result in `{foo: {}}`.

This is passing the sureberus test suite (with only one minor change in the test suite which was arguably already a bug), but it is DEFINITELY a non-backwards-compatible change. Juicebox's test suite failed with this change, and it's likely to break other code which had non-trivial schemas.


## Unrelated

This PR also adds a `schemas.Set` constructor, as well as support for `types: set` in schemas.