### PR TITLE
Adds date and datetime types to sureberus

### DIFF
--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from copy import deepcopy
+from datetime import datetime, date
 from inspect import getmembers
 import re
 import warnings
@@ -191,6 +192,8 @@ TYPES_BY_PRECEDENCE = [
     ("list", list),
     ("string", six.string_types),
     ("boolean", bool),
+    ("date", date),
+    ("datetime", datetime),
 ]
 TYPES = dict(TYPES_BY_PRECEDENCE)
 

--- a/sureberus/schema.py
+++ b/sureberus/schema.py
@@ -91,3 +91,11 @@ def List(required=True, _d=None, **kwargs):
 
 def Set(**kwargs):
     return mk(None, kwargs, type="set")
+
+
+def Date(required=True, **kwargs):
+    return mk(None, kwargs, type="date", required=required)
+
+
+def DateTime(required=True, **kwargs):
+    return mk(None, kwargs, type="datetime", required=required)

--- a/test_sure.py
+++ b/test_sure.py
@@ -5,6 +5,7 @@ import pytest
 from sureberus import normalize_dict, normalize_schema
 from sureberus import schema as S
 from sureberus import errors as E
+from datetime import date, datetime
 
 
 id_int = {"id": S.Integer()}
@@ -13,6 +14,31 @@ id_int = {"id": S.Integer()}
 def test_dict_of_int():
     sample = {"id": 3}
     assert normalize_dict(id_int, sample) == sample
+
+
+def test_dict_of_date():
+    id_date = {"id": S.Date()}
+    sample_date = {"id": datetime.now().date()}
+    sample_datetime = {"id": datetime.now()}
+    assert normalize_dict(id_date, sample_datetime) == sample_datetime
+    assert normalize_dict(id_date, sample_date) == sample_date
+
+    with pytest.raises(E.BadType):
+        normalize_dict(id_date, {"id": 3})
+
+
+def test_dict_of_datetime():
+    id_datetime = {"id": S.DateTime()}
+    sample_date = {"id": datetime.now().date()}
+    sample_datetime = {"id": datetime.now()}
+
+    assert normalize_dict(id_datetime, sample_datetime) == sample_datetime
+    # Dates are not datetimes
+    with pytest.raises(E.BadType):
+        assert normalize_dict(id_datetime, sample_date) == sample_date
+
+    with pytest.raises(E.BadType):
+        normalize_dict(id_datetime, {"id": 3})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds support `type: date` and `type: datetime`

Didn't update any docs because I couldn't find any list of supported types.