### PR TITLE
Workaround for pickling sureberus exceptions when values or schemas are not themselves pickleable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,14 +10,14 @@ pool:
   vmImage: 'ubuntu-latest'
 strategy:
   matrix:
-    Python27:
-      python.version: '2.7'
-    Python35:
-      python.version: '3.5'
-    Python36:
-      python.version: '3.6'
     Python37:
       python.version: '3.7'
+    Python38:
+      python.version: '3.8'
+    Python39:
+      python.version: '3.9'
+    Python310:
+      python.version: '3.10'
 
 steps:
 - task: UsePythonVersion@0

--- a/sureberus/__init__.py
+++ b/sureberus/__init__.py
@@ -111,11 +111,25 @@ INIT_CONTEXT = Context(
 
 
 def normalize_dict(dict_schema, value, stack=(), allow_unknown=False):
+    """Normalize a dictionary with a schema.
+
+    This is a legacy function. normalize_schema is preferred. This call:
+
+        normalize_dict(myschema, value)
+
+    should be replaced with this:
+
+        normalize_schema({"type": "dict", "fields": myschema}, value)
+    """
     ctx = INIT_CONTEXT.set_allow_unknown(allow_unknown)
     return _normalize_dict(dict_schema, value, ctx)
 
 
 def normalize_schema(schema, value, stack=(), allow_unknown=False):
+    """Normalize a value with a schema.
+
+    This is the main entrypoint into sureberus. It will validate and normalize the given
+    value, returning a new value."""
     ctx = INIT_CONTEXT.set_allow_unknown(allow_unknown)
     return _normalize_schema(schema, value, ctx)
 

--- a/sureberus/errors.py
+++ b/sureberus/errors.py
@@ -230,20 +230,3 @@ class RegisteredFunctionNotFound(SureError):
     setter = attr.ib()
     registry_name = attr.ib()
     stack = attr.ib()
-
-
-if __name__ == '__main__':
-    f = open("/tmp/blah", "w")
-    from sureberus import normalize_schema
-    import pickle
-    try:
-        normalize_schema({"type": "integer"}, f)
-    except Exception as e:
-        error = e
-    v = pickle.dumps(error)
-    print(v)
-    newv = pickle.loads(v)
-    print("OLD ERROR:")
-    print(error)
-    print("NEW ERROR:")
-    print(newv)

--- a/test_sure.py
+++ b/test_sure.py
@@ -1,3 +1,5 @@
+import pickle
+import tempfile
 from copy import deepcopy
 
 import pytest
@@ -1404,3 +1406,15 @@ def test_when_type_is_not_found():
 def test_metadata():
     schema = {"metadata": {"foo": "bar"}}
     normalize_schema(schema, {"foo": []}) == {"foo": []}
+
+
+def test_pickling():
+    f = tempfile.TemporaryFile()
+    schema = {"type": "integer"}
+    try:
+        normalize_schema(schema, f)
+    except Exception as e:
+        error = e
+
+    newerror = pickle.loads(pickle.dumps(error))
+    assert str(newerror) == str(error)


### PR DESCRIPTION
Forces exceptions to be pickled as Exception(str), throwing away the rich SureError type representation